### PR TITLE
Corrected notice file [skip travis]

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ LinkSmart IoT Learning Agent
 Copyright 2013 Fraunhofer-Gesellschaft
 
 This product includes software developed at
-Fraunhofer Institute for Applied Information Technology (http://fit.fraunhofer.de/).
+Fraunhofer Institute for Applied Information Technology (https://fit.fraunhofer.de/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,13 +1,5 @@
-    Copyright 2013 Fraunhofer-Gesellschaft
+LinkSmart IoT Learning Agent
+Copyright 2013 Fraunhofer-Gesellschaft
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+This product includes software developed at
+Fraunhofer Institute for Applied Information Technology (http://fit.fraunhofer.de/).


### PR DESCRIPTION
We put the copyright notice in NOTICE file. 

The notice file has a different format: http://www.apache.org/dev/licensing-howto.html#simple
And it is meant for Apache Software Foundation projects. We don't need to use it.
